### PR TITLE
Add GitHub Actions workflow for Markdown linting (Issue #15)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,34 @@
+name: Lint
+
+on:
+  push: null
+  pull_request: null
+
+permissions: {}
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: read
+      # To report GitHub Actions status checks
+      statuses: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          # super-linter needs the full git history to get the
+          # list of files that changed across commits
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Super-linter
+        uses: super-linter/super-linter@v8.2.0
+        env:
+          # To report GitHub Actions status checks
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_MARKDOWN: true


### PR DESCRIPTION
## Description
This PR adds a GitHub Actions workflow to automatically lint Markdown files in the repository, as requested in issue #15 ("Add the GitHub Super-Linter with just one check/test for Markdown linting").

### Changes Made
- Added `.github/workflows/lint.yml`: A workflow that triggers on pushes and pull requests, using Super-Linter (v8.2.0) with `VALIDATE_MARKDOWN=true` to check Markdown formatting (e.g., line lengths, bare URLs, code blocks).
- The workflow runs on Ubuntu and reports status checks to ensure code quality.

### Why This Helps
- Enforces consistent Markdown standards for documentation.
- Catches issues early in the contribution process.
- Supports Hacktoberfest by improving repository maintainability.

### Testing
- The workflow will run automatically on this PR and detect any existing Markdown linting issues (e.g., long lines in README.md).
- Local testing with `markdownlint-cli` confirmed the linter detects problems.
