### PR TITLE
ci: Enable yamllint in Super-Linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,4 +33,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_MARKDOWN: true
           VALIDATE_YAML: true
-          

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,3 +32,5 @@ jobs:
           # To report GitHub Actions status checks
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_MARKDOWN: true
+          VALIDATE_YAML: true
+          


### PR DESCRIPTION
Adds VALIDATE_YAML: true to the Super-Linter workflow to enable yamllint. Closes #18 #hacktoberfest